### PR TITLE
Update domainlist.pp

### DIFF
--- a/manifests/domainlist.pp
+++ b/manifests/domainlist.pp
@@ -35,6 +35,6 @@ define exim::domainlist (
   concat::fragment { "domainlist-${title}":
     target  => $::exim::config_path,
     content => template("${module_name}/list.erb"),
-    order   => 0002,
+    order   => '0002',
   }
 }


### PR DESCRIPTION
At least in our Puppet 4 setup, not using strings here will mix up the order inside the exim configuration.