### PR TITLE
Update hostlist.pp

### DIFF
--- a/manifests/hostlist.pp
+++ b/manifests/hostlist.pp
@@ -17,6 +17,6 @@ define exim::hostlist (
   concat::fragment { "hostlist-${title}":
     target  => $::exim::config_path,
     content => template("${module_name}/list.erb"),
-    order   => 0003,
+    order   => '0003',
   }
 }


### PR DESCRIPTION
At least in our Puppet 4 setup, not using strings here will mix up the order inside the exim configuration.