### PR TITLE
Fix service restart on redhat based systems

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@
 class exim::service {
   notice("service: ${::exim::manage_service}")
   if $::exim::manage_service {
-    service{'exim4':
+    service{$::exim::params::exim_service:
       ensure => running,
     }
   }


### PR DESCRIPTION
Use the service name definition from params.pp to fix service restarts on redhat based systems.