### PR TITLE
Additional configuration variables and fixes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1424,6 +1424,12 @@ Data type: `Any`
 
 Set the pipe_transport, used if the outcome of the router points to a pipe
 
+##### `reply_transport`
+
+Data type: `Any`
+
+Set the reply_transport, used if the outcome of the router points to mail or vacation
+
 Default value: `undef`
 
 ##### `qualify_preserve_domain`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1974,6 +1974,14 @@ Data type: `Any`
 
 Default value: `undef`
 
+##### `message_size_limit`
+
+Data type: `String`
+
+The string specified here is expanded and determines the maximum size of the message
+
+Default value: `undef`
+
 ##### `mode`
 
 Data type: `Any`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -736,6 +736,12 @@ Data type: `Optional[String]`
 
 Initial response to SMTP connections.
 
+##### `smtp_receive_timeout`
+
+Data type: `Optional[String]`
+
+Timeout for SMTP activity.
+
 ##### `smtp_reserve_hosts`
 
 Data type: `Optional[Array[String]]`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -67,6 +67,14 @@ Name of acl used for data checking
   (runs after SMTP "." command)
 Type: string
 
+##### `acl_smtp_predata`
+
+Data type: `Optional[String]`
+
+Name of acl used for checking after DATA command
+  (runs after SMTP "DATA" but before actual data)
+Type: string
+
 ##### `acl_smtp_mail`
 
 Data type: `Optional[String]`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -995,9 +995,15 @@ Default value: `undef`
 
 ##### `server_advertise_condition`
 
-Data type: `Any`
+Data type: `String`
 
 The condition under which to advertise this authenticator
+
+##### `server_debug_print`
+
+Data type: `String`
+
+Debug print when authentication debugging is enabled
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -993,6 +993,14 @@ The authentication check
 
 Default value: `undef`
 
+##### `server_advertise_condition`
+
+Data type: `Any`
+
+The condition under which to advertise this authenticator
+
+Default value: `undef`
+
 ##### `server_set_id`
 
 Data type: `Any`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -162,7 +162,15 @@ Data type: `Optional[Array[Integer]]`
 
 SMTP ports to listen on
 Type: array
-Example: [25, 587]
+Example: [25, 465, 587]
+
+##### `tls_on_connect_ports`
+
+Data type: `Optional[Array[Integer]]`
+
+Ports on which to start TLS on connect
+Type: array
+Example: [465]
 
 ##### `defaults`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -633,6 +633,13 @@ Data type: `Optional[String]`
 Max size allowed for mails, default is empty
 Example: 100M
 
+##### `mysql_servers`
+
+Data type: `Optional[Array[String]]`
+
+MySQL servers to connect to
+Type: array
+
 ##### `never_users`
 
 Data type: `Optional[Array[String]]`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1225,6 +1225,14 @@ Sets the caseful_local_part option.
 
 Default value: `undef`
 
+##### `retry_use_local_part`
+
+Data type: `Any`
+
+Sets the retry_use_local_part option.
+
+Default value: `undef`
+
 ##### `comment`
 
 Data type: `Any`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1570,6 +1570,38 @@ Protocol of transport.
 
 Default value: `undef`
 
+##### `quota`
+
+Data type: `String`
+
+Quota
+
+Default value: `undef`
+
+##### `quota_warn_threshold`
+
+Data type: `String`
+
+Quota warning threshold
+
+Default value: `undef`
+
+##### `quota_warn_message`
+
+Data type: `String`
+
+Quota warning message
+
+Default value: `undef`
+
+##### `maildir_use_size_file`
+
+Data type: `Boolean`
+
+Use Maildir size file for quota
+
+Default value: `false`
+
 ##### `connect_timeout`
 
 Data type: `Any`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -162,7 +162,7 @@ Data type: `Optional[Array[Integer]]`
 
 SMTP ports to listen on
 Type: array
-Example: ['25','587']
+Example: [25, 587]
 
 ##### `defaults`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -662,6 +662,12 @@ Data type: `Optional[Integer]`
 Limits the number of queue runners to run in parrallel.
 Type: integer
 
+##### `received_header_text`
+
+Data type: `Optional[String]`
+
+Override Received header added to messages.
+
 ##### `remote_max_parallel`
 
 Data type: `Optional[Integer]`

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -38,6 +38,7 @@ exim::check_spool_space: ~
 exim::chunking_advertise_hosts: ~
 exim::config_path: ~
 exim::daemon_smtp_ports: ~
+exim::tls_on_connect_ports: ~
 exim::delay_warning: ~
 exim::deliver_queue_load_max: ~
 exim::disable_ipv6: ~
@@ -108,6 +109,7 @@ exim::smtp_accept_queue: ~
 exim::smtp_accept_queue_per_connection: ~
 exim::smtp_accept_reserve: ~
 exim::smtp_banner: ~
+exim::smtp_receive_timeout: ~
 exim::smtp_reserve_hosts: ~
 exim::spamd_address: ~
 exim::split_spool_directory: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -27,6 +27,7 @@ exim::tls_advertise_hosts: [ '*' ]
 exim::acl_not_smtp: ~
 exim::acl_smtp_auth: ~
 exim::acl_smtp_data: ~
+exim::acl_smtp_predata: ~
 exim::acl_smtp_mail: ~
 exim::acl_smtp_mime: ~
 exim::allow_mx_to_ip: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -100,6 +100,7 @@ exim::qualify_domain: ~
 exim::queue_only_load: ~
 exim::queue_run_max: ~
 exim::queue_smtp_domains: ~
+exim::received_header_text: ~
 exim::remote_max_parallel: ~
 exim::smtp_accept_max: ~
 exim::smtp_accept_max_nonmail: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,6 +17,7 @@ exim::log_tls_peerdn: true
 exim::macros: {}
 exim::manage_service: false
 exim::never_users: [ 'root' ]
+exim::mysql_servers: ~
 exim::print_topbitchars: false
 exim::queue_only: false
 exim::rfc1413_hosts: '*'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,7 +22,7 @@ exim::queue_only: false
 exim::rfc1413_hosts: '*'
 exim::rfc1413_query_timeout: '5s'
 exim::timeout_frozen_after: '7d'
-exim::tls_advertise_hosts: [ '*' ]
+exim::tls_advertise_hosts: ~
 #
 exim::acl_not_smtp: ~
 exim::acl_smtp_auth: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -113,6 +113,7 @@ exim::smtp_accept_reserve: ~
 exim::smtp_banner: ~
 exim::smtp_receive_timeout: ~
 exim::smtp_reserve_hosts: ~
+exim::smtp_return_error_details: ~
 exim::spamd_address: ~
 exim::split_spool_directory: ~
 exim::syslog_timestamp: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,6 +26,7 @@ exim::timeout_frozen_after: '7d'
 exim::tls_advertise_hosts: ~
 #
 exim::acl_not_smtp: ~
+exim::acl_smtp_connect: ~
 exim::acl_smtp_auth: ~
 exim::acl_smtp_data: ~
 exim::acl_smtp_predata: ~

--- a/manifests/authenticator.pp
+++ b/manifests/authenticator.pp
@@ -31,6 +31,9 @@
 # @param server_advertise_condition
 #   The condition under which to advertise this authenticator
 #
+# @param server_debug_print
+#   Debug print when authentication debugging is enabled
+#
 # @param server_set_id
 #   Set the $authenticated_id variable for later use
 #
@@ -46,6 +49,7 @@ define exim::authenticator (
   Optional[String] $server_secret    = undef,
   Optional[String] $server_condition = undef,
   Optional[String] $server_advertise_condition = undef,
+  Optional[String] $server_debug_print = undef,
   Optional[String] $server_set_id    = undef,
   Optional[String] $server_prompts   = undef,
   ){

--- a/manifests/authenticator.pp
+++ b/manifests/authenticator.pp
@@ -28,6 +28,9 @@
 # @param server_condition
 #   The authentication check
 #
+# @param server_advertise_condition
+#   The condition under which to advertise this authenticator
+#
 # @param server_set_id
 #   Set the $authenticated_id variable for later use
 #
@@ -42,6 +45,7 @@ define exim::authenticator (
   Optional[String] $client_send      = undef,
   Optional[String] $server_secret    = undef,
   Optional[String] $server_condition = undef,
+  Optional[String] $server_advertise_condition = undef,
   Optional[String] $server_set_id    = undef,
   Optional[String] $server_prompts   = undef,
   ){

--- a/manifests/hostlist.pp
+++ b/manifests/hostlist.pp
@@ -12,7 +12,7 @@ define exim::hostlist (
 
   include exim
 
-  $list     = $hosts
+  $list     = regsubst($hosts, ':', '::', 'G')
   $listtype = 'hostlist'
   concat::fragment { "hostlist-${title}":
     target  => $::exim::config_path,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,8 +70,8 @@
 #
 # @param daemon_smtp_ports
 #   SMTP ports to listen on
-#   Type: array
-#   Example: ['25','587']
+#   Type: array of integers
+#   Example: [25,587]
 #
 # @param defaults
 #   Use a default configuration, this creates a simple default config,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -325,6 +325,10 @@
 #   Max size allowed for mails, default is empty
 #   Example: 100M
 #
+# @param mysql_servers
+#   MySQL servers to connect to
+#   Type: array
+#
 # @param never_users
 #   Do not run deliverys as these users
 #   Type: array
@@ -534,6 +538,7 @@ class exim (
   Boolean $manage_service,
   Optional[Boolean] $message_logs,
   Optional[String] $message_size_limit,
+  Optional[Array[String]] $mysql_servers,
   Optional[Array[String]] $never_users,
   Optional[Boolean] $untrusted_set_sender,
   Optional[Boolean] $print_topbitchars,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -383,6 +383,9 @@
 # @param smtp_banner
 #   Initial response to SMTP connections.
 #
+# @param received_header_text
+#   Override Received header added to each message.
+#
 # @param smtp_receive_timeout
 #   Timeout for SMTP activity.
 #
@@ -538,6 +541,7 @@ class exim (
   Optional[String] $qualify_domain,
   Optional[Integer] $queue_only_load,
   Optional[Integer] $queue_run_max,
+  Optional[String] $received_header_text,
   Optional[Integer] $remote_max_parallel,
   Optional[String] $rfc1413_hosts,
   Optional[String] $rfc1413_query_timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,11 @@
 #     (runs after SMTP "." command)
 #   Type: string
 #
+# @param acl_smtp_predata
+#   Name of acl used for checking after DATA command
+#     (runs after SMTP "DATA" but before actual data)
+#   Type: string
+#
 # @param acl_smtp_mail
 #   Name of acl used for mail checking
 #     (runs after SMTP "MAIL FROM:" command)
@@ -438,6 +443,7 @@ class exim (
   Optional[String] $acl_not_smtp,
   Optional[String] $acl_smtp_auth,
   Optional[String] $acl_smtp_data,
+  Optional[String] $acl_smtp_predata,
   Optional[String] $acl_smtp_mail,
   Optional[String] $acl_smtp_mime,
   Optional[String] $acl_smtp_rcpt,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,10 @@
 # @param acl_not_smtp
 #   Name of acl used for local generated mail. (sendmail)
 #
+# @param acl_smtp_connect
+#   Name of acl used on smtp connect
+#   Type: string
+#
 # @param acl_smtp_auth
 #   Name of acl used for auth checking
 #   Type: string
@@ -454,6 +458,7 @@
 #
 class exim (
   Optional[String] $acl_not_smtp,
+  Optional[String] $acl_smtp_connect,
   Optional[String] $acl_smtp_auth,
   Optional[String] $acl_smtp_data,
   Optional[String] $acl_smtp_predata,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,12 @@
 # @param daemon_smtp_ports
 #   SMTP ports to listen on
 #   Type: array of integers
-#   Example: [25,587]
+#   Example: [25,465,587]
+#
+# @param tls_on_connect_ports
+#   Ports on which to enable TLs on connect
+#   Type: array of integers
+#   Example: [465]
 #
 # @param defaults
 #   Use a default configuration, this creates a simple default config,
@@ -445,6 +450,7 @@ class exim (
   Optional[Array[String]] $queue_smtp_domains,
   String $config_path,
   Optional[Array[Integer]] $daemon_smtp_ports,
+  Optional[Array[Integer]] $tls_on_connect_ports,
   Optional[Boolean] $defaults,
   Optional[Array[String]] $delay_warning,
   Optional[Integer] $deliver_queue_load_max,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -396,6 +396,9 @@
 # @param smtp_reserve_hosts
 #   See "smtp_accept_reserve"
 #
+# @param smtp_return_error_details
+#   Return more detailed SMTP error messages.
+#
 # @param spamd_address
 #   Configure a spamd socket here.
 #
@@ -560,6 +563,7 @@ class exim (
   Optional[String] $smtp_banner,
   Optional[String] $smtp_receive_timeout,
   Optional[Array[String]] $smtp_reserve_hosts,
+  Optional[Boolean] $smtp_return_error_details,
   Optional[String] $spamd_address,
   Optional[Boolean] $split_spool_directory,
   Optional[Boolean] $syslog_timestamp,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -383,6 +383,9 @@
 # @param smtp_banner
 #   Initial response to SMTP connections.
 #
+# @param smtp_receive_timeout
+#   Timeout for SMTP activity.
+#
 # @param smtp_reserve_hosts
 #   See "smtp_accept_reserve"
 #
@@ -546,6 +549,7 @@ class exim (
   Optional[Integer] $smtp_accept_queue_per_connection,
   Optional[Integer] $smtp_accept_reserve,
   Optional[String] $smtp_banner,
+  Optional[String] $smtp_receive_timeout,
   Optional[Array[String]] $smtp_reserve_hosts,
   Optional[String] $spamd_address,
   Optional[Boolean] $split_spool_directory,

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -13,6 +13,9 @@
 # @param caseful_local_part
 #   Sets the caseful_local_part option.
 #
+# @param retry_use_local_part
+#   Sets the retry_use_local_part option.
+#
 # @param comment
 #   Comment a router, this will be placed as a comment just above
 #   the router.
@@ -136,6 +139,7 @@ define exim::router (
   Optional[Boolean] $allow_fail                 = false,
   Optional[Boolean] $allow_filter               = false,
   Optional[Boolean] $caseful_local_part                 = undef,
+  Optional[Boolean] $retry_use_local_part                 = undef,
   Optional[Array[String]] $comment                            = undef,
   Optional[String] $condition                          = undef,
   Optional[String] $data                               = undef,

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -91,6 +91,9 @@
 # @param pipe_transport
 #   Set the pipe_transport, used if the outcome of the router points to a pipe
 #
+# @param reply_transport
+#   Set the reply_transport, used if the outcome of the router points to mail or vacation
+#
 # @param qualify_preserve_domain
 #   For redirect routers
 #   If an unqualified address (one without a domain) is generated, it is qualified with the domain of the parent address.
@@ -161,6 +164,7 @@ define exim::router (
   Optional[Boolean] $no_more                    = false,
   Optional[Boolean] $no_verify                  = false,
   Optional[String] $pipe_transport                     = undef,
+  Optional[String] $reply_transport                    = undef,
   Optional[Boolean] $qualify_preserve_domain    = false,
   Optional[String] $route_data                         = undef,
   Optional[String] $route_list                         = undef,

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -20,6 +20,18 @@
 # @param protocol
 #   Protocol of transport
 #
+# @param quota
+#   Quota
+#
+# @param quota_warn_threshold
+#   Quota warning threshold
+#
+# @param quota_warn_message
+#   Quota warning message
+#
+# @param maildir_use_size_file
+#   Use maildir size file for quota
+#
 # @param connect_timeout
 #   Timeout when connecting to remote Servers
 #
@@ -332,6 +344,10 @@ define exim::transport (
   Optional[String[1]]     $once_repeat               = undef,
   Optional[String[1]]     $path                      = undef,
   Optional[String[1]]     $protocol                  = undef,
+  Optional[String[1]]     $quota                     = undef,
+  Optional[String[1]]     $quota_warn_threshold      = undef,
+  Optional[String[1]]     $quota_warn_message        = undef,
+  Boolean                 $maildir_use_size_file     = false,
   Optional[String[1]]     $return_message            = undef,
   Optional[String[1]]     $socket                    = undef,
   Optional[String[1]]     $subject                   = undef,

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -29,6 +29,9 @@
 # @param quota_warn_message
 #   Quota warning message
 #
+# @param quota_is_inclusive
+#   Whether quota is inclusive
+#
 # @param maildir_use_size_file
 #   Use maildir size file for quota
 #
@@ -347,6 +350,7 @@ define exim::transport (
   Optional[String[1]]     $quota                     = undef,
   Optional[String[1]]     $quota_warn_threshold      = undef,
   Optional[String[1]]     $quota_warn_message        = undef,
+  Boolean                 $quota_is_inclusive        = true,
   Boolean                 $maildir_use_size_file     = false,
   Optional[String[1]]     $return_message            = undef,
   Optional[String[1]]     $socket                    = undef,

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -247,6 +247,9 @@
 #   The string specified here is expanded and output at the end of every
 #   message
 #
+# @param message_size_limit
+#   The string specified here is expanded and determines the maximum size of the message
+#
 # @param mode
 #   If the output file is created, it is given this mode
 #
@@ -322,6 +325,7 @@ define exim::transport (
   Optional[String[1]]     $maildir_tag               = undef,
   Optional[String[1]]     $message_prefix            = undef,
   Optional[String[1]]     $message_suffix            = undef,
+  Optional[String[1]]     $message_size_limit        = undef,
   Optional[String[1]]     $mode                      = undef,
   Optional[String[1]]     $once                      = undef,
   Optional[String[1]]     $once_file_size            = undef,

--- a/spec/classes/exim_spec.rb
+++ b/spec/classes/exim_spec.rb
@@ -29,7 +29,7 @@ describe 'exim', type: 'class' do
     it { is_expected.to contain_concat__fragment('main').with_content(%r{^ldap_default_servers\s+= ldap1 : ldap2$}) }
   end
 
-  ['acl_smtp_mail', 'acl_smtp_rcpt', 'acl_smtp_data', 'acl_smtp_mime'].each do |parameter|
+  ['acl_smtp_mail', 'acl_smtp_rcpt', 'acl_smtp_data', 'acl_smtp_predata', 'acl_smtp_mime'].each do |parameter|
     context parameter do
       let(:params) { { parameter => 'acl_check' } }
 

--- a/spec/classes/exim_spec.rb
+++ b/spec/classes/exim_spec.rb
@@ -29,7 +29,7 @@ describe 'exim', type: 'class' do
     it { is_expected.to contain_concat__fragment('main').with_content(%r{^ldap_default_servers\s+= ldap1 : ldap2$}) }
   end
 
-  ['acl_smtp_mail', 'acl_smtp_rcpt', 'acl_smtp_data', 'acl_smtp_predata', 'acl_smtp_mime'].each do |parameter|
+  ['acl_smtp_connect', 'acl_smtp_mail', 'acl_smtp_rcpt', 'acl_smtp_data', 'acl_smtp_predata', 'acl_smtp_mime'].each do |parameter|
     context parameter do
       let(:params) { { parameter => 'acl_check' } }
 

--- a/spec/defines/router_spec.rb
+++ b/spec/defines/router_spec.rb
@@ -12,7 +12,7 @@ describe 'exim::router', type: 'define' do
     it { is_expected.to contain_concat__fragment('router-testrouter') }
   end
 
-  ['caseful_local_part'].each do |parameter|
+  ['caseful_local_part', 'retry_use_local_part'].each do |parameter|
     describe parameter do
       let(:params) { { parameter => true, order: 1, driver: 'redirect' } }
 

--- a/spec/defines/transport_spec.rb
+++ b/spec/defines/transport_spec.rb
@@ -66,7 +66,8 @@ describe 'exim::transport', type: 'define' do
 
   bool_parameter = ['delivery_date_add', 'envelope_to_add', 'freeze_exec_fail', 'initgroups',
                     'log_output', 'maildir_format', 'return_path_add', 'rcpt_include_affixes',
-                    'allow_localhost', 'return_output', 'return_fail_output', 'timeout_defer']
+                    'allow_localhost', 'return_output', 'return_fail_output', 'timeout_defer',
+                    'maildir_use_size_file']
 
   bool_parameter.each do |parameter|
     describe parameter do

--- a/spec/defines/transport_spec.rb
+++ b/spec/defines/transport_spec.rb
@@ -30,7 +30,7 @@ describe 'exim::transport', type: 'define' do
   string_parameter = ['directory', 'maildir_tag', 'command', 'connect_timeout', 'directory_mode',
                       'file', 'group', 'home_directory', 'message_prefix', 'message_suffix',
                       'mode', 'subject', 'text', 'to', 'transport_filter', 'user', 'socket',
-                      'interface', 'helo_data', 'timeout', 'path', 'from']
+                      'interface', 'helo_data', 'timeout', 'path', 'from', 'message_size_limit']
 
   string_parameter.each do |parameter|
     describe parameter do

--- a/templates/acl/acl-header.erb
+++ b/templates/acl/acl-header.erb
@@ -24,6 +24,9 @@ acl_smtp_auth    = <%= @acl_smtp_auth %>
 <% if @acl_smtp_data -%>
 acl_smtp_data    = <%= @acl_smtp_data %>
 <% end -%>
+<% if @acl_smtp_predata -%>
+acl_smtp_predata = <%= @acl_smtp_predata %>
+<% end -%>
 <% if @acl_smtp_mime -%>
 acl_smtp_mime    = <%= @acl_smtp_mime %>
 <% end -%>

--- a/templates/authenticator/authenticator.erb
+++ b/templates/authenticator/authenticator.erb
@@ -19,6 +19,9 @@
 <% unless @server_advertise_condition.nil? -%>
   server_advertise_condition = <%= @server_advertise_condition %>
 <% end -%>
+<% unless @server_debug_print.nil? -%>
+  server_debug_print = <%= @server_debug_print %>
+<% end -%>
 <% unless @server_set_id.nil? -%>
   server_set_id    = <%= @server_set_id %>
 <% end -%>

--- a/templates/authenticator/authenticator.erb
+++ b/templates/authenticator/authenticator.erb
@@ -16,6 +16,9 @@
 <% unless @server_condition.nil? -%>
   server_condition = <%= @server_condition %>
 <% end -%>
+<% unless @server_advertise_condition.nil? -%>
+  server_advertise_condition = <%= @server_advertise_condition %>
+<% end -%>
 <% unless @server_set_id.nil? -%>
   server_set_id    = <%= @server_set_id %>
 <% end -%>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -164,8 +164,10 @@ received_header_text       = <%= @received_header_text %>
 <% unless @qualify_domain.nil?                     -%>qualify_domain                     = <%= @qualify_domain %>
 <% end -%>
 
-<% unless @tls_certificate.nil? && @tls_privatekey.nil? -%>
+<% unless @tls_advertise_hosts.nil? -%>
 tls_advertise_hosts                = <%= @tls_advertise_hosts.join(" : ") %>
+<% end -%>
+<% unless @tls_certificate.nil? && @tls_privatekey.nil? -%>
 tls_certificate                    = <%= @tls_certificate %>
 tls_privatekey                     = <%= @tls_privatekey %>
 <% end -%>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -141,6 +141,7 @@ log_selector               = <% unless @log_lost_incoming_connection.nil? -%><% 
 <% unless @log_timezone.nil?                       -%>log_timezone                       = <%= @log_timezone %>
 <% end -%>
 
+<%- if @received_header_text.nil? -%>
 received_header_text       = Received: \
   ${if def:sender_rcvhost {from $sender_rcvhost\n\t}\
   {${if def:sender_ident \
@@ -154,6 +155,9 @@ received_header_text       = Received: \
   {(envelope-from <$sender_address>)\n\t}}\
   id $message_exim_id\
   ${if def:received_for {\n\tfor $received_for}}
+<%- else -%>
+received_header_text       = <%= @received_header_text %>
+<%- end -%>
 
 <% unless @errors_reply_to.nil?                    -%>errors_reply_to                    = <%= @errors_reply_to %>
 <% end -%>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -159,7 +159,7 @@ received_header_text       = Received: \
 <% end -%>
 
 <% unless @tls_certificate.nil? && @tls_privatekey.nil? -%>
-tls_advertise_hosts                = <%= @tls_advertise_hosts %>
+tls_advertise_hosts                = <%= @tls_advertise_hosts.join(" : ") %>
 tls_certificate                    = <%= @tls_certificate %>
 tls_privatekey                     = <%= @tls_privatekey %>
 <% end -%>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -209,3 +209,6 @@ tls_privatekey                     = <%= @tls_privatekey %>
 <% unless @extract_addresses_remove_arguments.nil? -%>extract_addresses_remove_arguments = <%= @extract_addresses_remove_arguments %>
 <% end -%>
 
+<% unless @mysql_servers.nil?                       -%>hide mysql_servers                = <%= @mysql_servers.map{|i| i.gsub(':', '::')}.join(" : ") %>
+
+<% end -%>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -26,6 +26,8 @@ keep_environment =
 <% end -%>
 <% unless @daemon_smtp_ports.nil?                  -%>daemon_smtp_ports                  = <%= @daemon_smtp_ports.join(" : ") %>
 <% end -%>
+<% unless @tls_on_connect_ports.nil?               -%>tls_on_connect_ports               = <%= @tls_on_connect_ports.join(" : ") %>
+<% end -%>
 <% unless @disable_ipv6.nil?                       -%>disable_ipv6                       = <%= @disable_ipv6 %>
 <% end -%>
 <% unless @hosts_treat_as_local.nil?               -%>hosts_treat_as_local               = <%= @hosts_treat_as_local.join(" : ") %>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -194,6 +194,8 @@ tls_privatekey                     = <%= @tls_privatekey %>
 <% end -%>
 <% unless @smtp_reserve_hosts.nil?                 -%>smtp_reserve_hosts                 = <%= @smtp_reserve_hosts.join(' : ') %>
 <% end -%>
+<% unless @smtp_return_error_details.nil?          -%>smtp_return_error_details          = <%= @smtp_return_error_details %>
+<% end -%>
 <% unless @deliver_queue_load_max.nil?             -%>deliver_queue_load_max             = <%= @deliver_queue_load_max %>
 <% end -%>
 <% unless @queue_only_load.nil?                    -%>queue_only_load                    = <%= @queue_only_load %>

--- a/templates/base.erb
+++ b/templates/base.erb
@@ -136,6 +136,8 @@ log_selector               = <% unless @log_lost_incoming_connection.nil? -%><% 
 <% end -%>
 <% unless @smtp_banner.nil?                        -%>smtp_banner                        = <%= @smtp_banner %>
 <% end -%>
+<% unless @smtp_receive_timeout.nil?               -%>smtp_receive_timeout                = <%= @smtp_receive_timeout %>
+<% end -%>
 <% unless @log_timezone.nil?                       -%>log_timezone                       = <%= @log_timezone %>
 <% end -%>
 

--- a/templates/router/router.erb
+++ b/templates/router/router.erb
@@ -68,6 +68,9 @@
 <% unless @pipe_transport.nil? -%>
   pipe_transport = <%= @pipe_transport %>
 <% end -%>
+<% unless @reply_transport.nil? -%>
+  reply_transport = <%= @reply_transport %>
+<% end -%>
 <% unless @route_data.nil? -%>
   route_data   = <%= @route_data %>
 <% end -%>

--- a/templates/router/router.erb
+++ b/templates/router/router.erb
@@ -17,6 +17,9 @@
 <% unless @caseful_local_part.nil? -%>
   caseful_local_part = <%= @caseful_local_part %>
 <% end -%>
+<% unless @retry_use_local_part.nil? -%>
+  retry_use_local_part = <%= @retry_use_local_part %>
+<% end -%>
 <% unless @condition.nil? -%>
   condition    = <%= @condition %>
 <% end -%>

--- a/templates/transport/transport.erb
+++ b/templates/transport/transport.erb
@@ -96,6 +96,9 @@
 <% unless @message_suffix.nil? -%>
   message_suffix  = <%= @message_suffix %>
 <% end -%>
+<% unless @message_size_limit.nil? -%>
+  message_size_limit = <%= @message_size_limit %>
+<% end -%>
 <% unless @transport_filter.nil? -%>
   transport_filter = <%= @transport_filter %>
 <% end -%>

--- a/templates/transport/transport.erb
+++ b/templates/transport/transport.erb
@@ -189,4 +189,16 @@
 <% if @return_message -%>
   return_message  = <%= @return_message %>
 <% end -%>
+<% unless @quota.nil? -%>
+  quota                 = <%= @quota %>
+<% end -%>
+<% unless @quota_warn_threshold.nil? -%>
+  quota_warn_threshold  = <%= @quota_warn_threshold %>
+<% end -%>
+<% unless @quota_warn_message.nil? -%>
+  quota_warn_message    = <%= @quota_warn_message %>
+<% end -%>
+<% if @maildir_use_size_file -%>
+  maildir_use_size_file
+<% end -%>
 

--- a/templates/transport/transport.erb
+++ b/templates/transport/transport.erb
@@ -198,6 +198,9 @@
 <% unless @quota_warn_message.nil? -%>
   quota_warn_message    = <%= @quota_warn_message %>
 <% end -%>
+<% unless @quota_is_inclusive -%>
+  quota_is_inclusive    = false
+<% end -%>
 <% if @maildir_use_size_file -%>
   maildir_use_size_file
 <% end -%>


### PR DESCRIPTION
Allow setting acl_smtp_predata, tls_on_connect_ports, smtp_receive_timeout, received_header_text, mysql_servers, server_advertise_condition (authenticator), server_debug_print (authenticator), retry_use_local_part (router), reply_transport (router), message_size_limit (on transports - previously only possible globally), quota/quota_warn_threshold/quota_warn_message/quota_is_inclusive (transport)

Fix joining of tls_advertise_hosts and allow it to be set even if no tls_certificate defined. Fix IPv6 addresses in hostlists.

fixes #40 #41 #43