### PR TITLE
extend condition for epel usage

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class exim::install (
   package { $exim_package:
     ensure => installed,
   }
-  if ($facts['os']['family'] == 'redhat') {
+  if ($use_epel and $facts['os']['family'] == 'redhat') {
     Class['Epel'] -> Package[$exim_package]
   }
 }


### PR DESCRIPTION
The relationship to the Epel-class is not necessary if `use_epel` is set to False.