### PR TITLE
add smtp transport option message_linelength_limit

### DIFF
--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -269,6 +269,9 @@
 # @param message_size_limit
 #   The string specified here is expanded and determines the maximum size of the message
 #
+# @param message_linelength_limit
+#   This option sets the maximum line length, in bytes, that the transport will send.
+#
 # @param mode
 #   If the output file is created, it is given this mode
 #
@@ -350,6 +353,7 @@ define exim::transport (
   Optional[String[1]]     $message_prefix            = undef,
   Optional[String[1]]     $message_suffix            = undef,
   Optional[String[1]]     $message_size_limit        = undef,
+  Optional[Integer]       $message_linelength_limit  = undef,
   Optional[String[1]]     $mode                      = undef,
   Optional[String[1]]     $once                      = undef,
   Optional[String[1]]     $once_file_size            = undef,

--- a/spec/defines/transport_spec.rb
+++ b/spec/defines/transport_spec.rb
@@ -10,7 +10,7 @@ describe 'exim::transport', type: 'define' do
     it { is_expected.to contain_concat__fragment('transport-header') }
   end
 
-  integer_parameter = ['batch_max', 'port', 'connection_max_messages', 'tls_dh_min_bits']
+  integer_parameter = ['batch_max', 'port', 'connection_max_messages', 'tls_dh_min_bits', 'message_linelength_limit']
 
   integer_parameter.each do |parameter|
     describe parameter do

--- a/templates/transport/transport.erb
+++ b/templates/transport/transport.erb
@@ -99,6 +99,9 @@
 <% unless @message_size_limit.nil? -%>
   message_size_limit = <%= @message_size_limit %>
 <% end -%>
+<% unless @message_linelength_limit.nil? -%>
+  message_linelength_limit = <%= @message_linelength_limit %>
+<% end -%>
 <% unless @transport_filter.nil? -%>
   transport_filter = <%= @transport_filter %>
 <% end -%>


### PR DESCRIPTION
Add the smtp-transport option `message_linelength_limit`.